### PR TITLE
feat: add keybinding to open dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Run the following command to open the dashboard:
 
 ## Mappings
 
-| Key | Action    |
+| Key | Action |
 | --- | --------- |
+| `<leader>gw` | Open dashboard |
 | `<` | prev year |
 | `>` | next year |
 

--- a/plugin/wrapped.lua
+++ b/plugin/wrapped.lua
@@ -2,6 +2,8 @@ if vim.g.wrapped_loaded == 1 then return end
 
 vim.g.wrapped_loaded = 1
 
+vim.keymap.set("n", "<leader>gw", ":WrappedNvim<CR>", { desc = "Open Wrapped dashboard" })
+
 vim.api.nvim_create_user_command(
   "NvimWrapped",
   function() require("wrapped").run() end,


### PR DESCRIPTION
## Overview

Add a global keybinding to open the Wrapped dashboard without typing the `:WrappedNvim` command manually.

This change addresses the need for a more efficient workflow, as Neovim users typically prefer keyboard shortcuts over typing commands manually.

## Key Changes

- Added `<leader>gw` as a global keybinding in `plugin/wrapped.lua`
- Updated `README.md` with the new mapping in the Mappings table

## Impact

- `plugin/wrapped.lua` — Added keymap
- `README.md` — Documentation update