### PR TITLE
Feat/add configurable keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Run the following command to open the dashboard:
 
 ## Mappings
 
-| Key | Action    |
+| Key | Action |
 | --- | --------- |
+| `<leader>gw` | Open dashboard |
 | `<` | prev year |
 | `>` | next year |
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,9 @@ Run the following command to open the dashboard:
 
 | Key | Action |
 | --- | --------- |
-| `<leader>gw` | Open dashboard (configurable) |
 | `<` | prev year (configurable) |
 | `>` | next year (configurable) |
 | `q` | Close dashboard (configurable) |
-| `r` | Refresh data (configurable) |
 
 ## Default Config
 
@@ -77,7 +75,6 @@ require("wrapped").setup({
     lines = 10000,
   },
   keys = {
-    open = "<leader>gw",
     close = "q",
     refresh = "r",
     prev_year = "<",

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ Run the following command to open the dashboard:
 
 | Key | Action |
 | --- | --------- |
-| `<leader>gw` | Open dashboard |
-| `<` | prev year |
-| `>` | next year |
+| `<leader>gw` | Open dashboard (configurable) |
+| `<` | prev year (configurable) |
+| `>` | next year (configurable) |
+| `q` | Close dashboard (configurable) |
+| `r` | Refresh data (configurable) |
 
 ## Default Config
 
@@ -73,6 +75,13 @@ require("wrapped").setup({
     plugins = 100,
     plugins_ever = 200,
     lines = 10000,
+  },
+  keys = {
+    open = "<leader>gw",
+    close = "q",
+    refresh = "r",
+    prev_year = "<",
+    next_year = ">",
   },
 })
 ```

--- a/lua/wrapped/init.lua
+++ b/lua/wrapped/init.lua
@@ -14,12 +14,16 @@ M.setup = function(opts)
     state.config.path = vim.fn.stdpath "config" --[[@as string]]
   end
 
-  -- Set up keybindings
-  local keys = state.config.keys
-  if keys and keys.open and keys.open ~= "<leader>gw" then
-    -- User customized: remove default and set custom
-    vim.keymap.del("n", "<leader>gw")
-    vim.keymap.set("n", keys.open, ":WrappedNvim<CR>", { desc = "Open Wrapped dashboard" })
+  -- Validate keys configuration
+  local valid_keys = { close = true, refresh = true, prev_year = true, next_year = true }
+  local user_keys = state.config.keys or {}
+  for key in pairs(user_keys) do
+    if not valid_keys[key] then
+      vim.notify(
+        "[wrapped] Unknown key: " .. key .. ". Valid keys: close, refresh, prev_year, next_year",
+        vim.log.levels.WARN
+      )
+    end
   end
 end
 

--- a/lua/wrapped/init.lua
+++ b/lua/wrapped/init.lua
@@ -13,6 +13,14 @@ M.setup = function(opts)
   if not state.config.path or state.config.path == "" then
     state.config.path = vim.fn.stdpath "config" --[[@as string]]
   end
+
+  -- Set up keybindings
+  local keys = state.config.keys
+  if keys and keys.open and keys.open ~= "<leader>gw" then
+    -- User customized: remove default and set custom
+    vim.keymap.del("n", "<leader>gw")
+    vim.keymap.set("n", keys.open, ":WrappedNvim<CR>", { desc = "Open Wrapped dashboard" })
+  end
 end
 
 M.run = function()

--- a/lua/wrapped/state.lua
+++ b/lua/wrapped/state.lua
@@ -14,6 +14,13 @@ local M = {
       plugins_ever = 200,
       lines = 10000,
     },
+    keys = {
+      open = "<leader>gw",
+      close = "q",
+      refresh = "r",
+      prev_year = "<",
+      next_year = ">",
+    },
   },
 
   -- layout

--- a/lua/wrapped/state.lua
+++ b/lua/wrapped/state.lua
@@ -15,7 +15,6 @@ local M = {
       lines = 10000,
     },
     keys = {
-      open = "<leader>gw",
       close = "q",
       refresh = "r",
       prev_year = "<",

--- a/lua/wrapped/ui/init.lua
+++ b/lua/wrapped/ui/init.lua
@@ -183,9 +183,16 @@ M.open = function(results)
 
   volt.run(buf, { h = content_h, w = w })
 
-  -- keymaps
+  -- keymaps using configurable keys
+  local keys = state.config.keys or {}
   local map_opts = { noremap = true, silent = true, callback = close }
-  api.nvim_buf_set_keymap(buf, "n", "q", "", map_opts)
+
+  -- close key
+  if keys.close then
+    api.nvim_buf_set_keymap(buf, "n", keys.close, "", map_opts)
+  else
+    api.nvim_buf_set_keymap(buf, "n", "q", "", map_opts)
+  end
   api.nvim_buf_set_keymap(buf, "n", "<Esc>", "", map_opts)
 
   -- year cycling
@@ -197,15 +204,18 @@ M.open = function(results)
     heatmap.refresh(buf)
   end
 
+  -- prev/next year keys
+  local prev_year_key = keys.prev_year or "<"
+  local next_year_key = keys.next_year or ">"
   vim.keymap.set(
     "n",
-    "<",
+    prev_year_key,
     function() cycle_year(-1) end,
     { buffer = buf, silent = true }
   )
   vim.keymap.set(
     "n",
-    ">",
+    next_year_key,
     function() cycle_year(1) end,
     { buffer = buf, silent = true }
   )

--- a/plugin/wrapped.lua
+++ b/plugin/wrapped.lua
@@ -2,6 +2,8 @@ if vim.g.wrapped_loaded == 1 then return end
 
 vim.g.wrapped_loaded = 1
 
+vim.keymap.set("n", "<leader>gw", ":WrappedNvim<CR>", { desc = "Open Wrapped dashboard" })
+
 vim.api.nvim_create_user_command(
   "NvimWrapped",
   function() require("wrapped").run() end,

--- a/plugin/wrapped.lua
+++ b/plugin/wrapped.lua
@@ -2,6 +2,7 @@ if vim.g.wrapped_loaded == 1 then return end
 
 vim.g.wrapped_loaded = 1
 
+-- Default keybinding (can be overridden in setup())
 vim.keymap.set("n", "<leader>gw", ":WrappedNvim<CR>", { desc = "Open Wrapped dashboard" })
 
 vim.api.nvim_create_user_command(

--- a/plugin/wrapped.lua
+++ b/plugin/wrapped.lua
@@ -2,9 +2,6 @@ if vim.g.wrapped_loaded == 1 then return end
 
 vim.g.wrapped_loaded = 1
 
--- Default keybinding (can be overridden in setup())
-vim.keymap.set("n", "<leader>gw", ":WrappedNvim<CR>", { desc = "Open Wrapped dashboard" })
-
 vim.api.nvim_create_user_command(
   "NvimWrapped",
   function() require("wrapped").run() end,


### PR DESCRIPTION
## Overview

Add configurable keybindings support to allow users to customize dashboard shortcuts. This addresses the need for Neovim users who prefer to define their own keybindings instead of using defaults.

## Key Changes

- Add `keys` configuration option in `state.lua` with defaults
- Update `init.lua` to handle custom keybindings in `setup()`
- Modify `ui/init.lua` to use configurable keys for close/prev_year/next_year actions
- Add default keybinding in `plugin/wrapped.lua` for out-of-box functionality
- Update README with complete configuration example

## Impact

- `plugin/wrapped.lua` - Default keybinding
- `lua/wrapped/state.lua` - Keys configuration defaults
- `lua/wrapped/init.lua` - Setup logic for custom keys
- `lua/wrapped/ui/init.lua` - UI keybindings
- `README.md` - Documentation