### PR TITLE
feat: auto-detect git repository as default path

### DIFF
--- a/lua/wrapped/init.lua
+++ b/lua/wrapped/init.lua
@@ -11,7 +11,19 @@ local loading = require "wrapped.ui.loading"
 M.setup = function(opts)
   state.config = vim.tbl_deep_extend("force", state.config, opts or {})
   if not state.config.path or state.config.path == "" then
-    state.config.path = vim.fn.stdpath "config" --[[@as string]]
+    local cwd = vim.fn.getcwd()
+    local git_dir = cwd .. "/.git"
+
+    if vim.fn.isdirectory(git_dir) == 1 then
+      state.config.path = cwd
+    else
+      vim.notify(
+        "[wrapped] No se detectó repositorio git en el directorio actual.\n"
+          .. "Por favor especificá una ruta con `require('wrapped').setup({ path = '/tu/repo' })`",
+        vim.log.levels.ERROR
+      )
+      return
+    end
   end
 
   -- Validate keys configuration
@@ -28,6 +40,23 @@ M.setup = function(opts)
 end
 
 M.run = function()
+  -- Validar path antes de ejecutar
+  if not state.config.path or state.config.path == "" then
+    local cwd = vim.fn.getcwd()
+    local git_dir = cwd .. "/.git"
+
+    if vim.fn.isdirectory(git_dir) == 1 then
+      state.config.path = cwd
+    else
+      vim.notify(
+        "[wrapped] No se detectó repositorio git en el directorio actual.\n"
+          .. "Por favor especificá una ruta con `require('wrapped').setup({ path = '/tu/repo' })`",
+        vim.log.levels.ERROR
+      )
+      return
+    end
+  end
+
   ---@type Wrapped.Results
   local results = {}
   local total = 3

--- a/lua/wrapped/state.lua
+++ b/lua/wrapped/state.lua
@@ -4,7 +4,7 @@ local api = vim.api
 local M = {
   -- user config
   config = {
-    path = vim.fn.stdpath "config",
+    path = nil,
     border = false,
     size = { width = 120, height = 40 },
     exclude_filetype = { ".gitmodules" },


### PR DESCRIPTION
- Add automatic detection of .git directory in current working directory
- Fallback to nvim config only when explicitly specified by user
- Add validation in run() to ensure path always contains valid git repo
- Display error notification when no git repository is detected
- Change default path in state to nil to enable validation logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project path configuration now requires a Git repository in the current directory or explicit path specification. An error notification displays when neither requirement is met.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aikhe/wrapped.nvim/pull/17)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->