### PR TITLE
Added functionality for setting nvim root

### DIFF
--- a/lua/wrapped/core/files.lua
+++ b/lua/wrapped/core/files.lua
@@ -8,7 +8,7 @@ local function get_path()
   return p
 end
 
---@return string nvim_root
+---@return string nvim_root
 local function get_nvim_root()
   local p = require("wrapped.state").config.nvim_root or ""
   p = (":/%s"):format(p)
@@ -72,86 +72,82 @@ function M.get_stats_async(cb)
         { cwd = config_path, text = true },
         function(diff_out)
           -- also get untracked files
-          vim.system(
-            {
-              "git",
-              "ls-files",
-              "--others",
-              "--exclude-standard",
-              "--",
-              nvim_root,
-            },
-            { cwd = config_path, text = true },
-            function(ls_out)
-              vim.schedule(function()
-                local stats = { ---@type Wrapped.FileStats
-                  total_lines = 0,
-                  biggest = { name = "", lines = 0 },
-                  smallest = { name = "", lines = math.huge },
-                  lines_by_type = {},
-                  top_files = {},
-                }
+          vim.system({
+            "git",
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "--",
+            nvim_root,
+          }, { cwd = config_path, text = true }, function(ls_out)
+            vim.schedule(function()
+              local stats = { ---@type Wrapped.FileStats
+                total_lines = 0,
+                biggest = { name = "", lines = 0 },
+                smallest = { name = "", lines = math.huge },
+                lines_by_type = {},
+                top_files = {},
+              }
 
-                local excluded_config = require("wrapped.state").config.exclude_filetype
-                  or {}
-                local excluded = {}
-                for _, ext in ipairs(excluded_config) do
-                  excluded[ext] = true
+              local excluded_config = require("wrapped.state").config.exclude_filetype
+                or {}
+              local excluded = {}
+              for _, ext in ipairs(excluded_config) do
+                excluded[ext] = true
+              end
+
+              -- parse tracked/modified
+              local diff_lines =
+                vim.split(diff_out.stdout or "", "\n", { trimempty = true })
+              for _, line in ipairs(diff_lines) do
+                local added, _, file = line:match "^(%d+)%s+(%d+)%s+(.+)$"
+                if added and file then
+                  M._process_file(
+                    stats,
+                    excluded,
+                    file,
+                    tonumber(added, 10) or 0
+                  )
                 end
+              end
 
-                -- parse tracked/modified
-                local diff_lines =
-                  vim.split(diff_out.stdout or "", "\n", { trimempty = true })
-                for _, line in ipairs(diff_lines) do
-                  local added, _, file = line:match "^(%d+)%s+(%d+)%s+(.+)$"
-                  if added and file then
-                    M._process_file(
-                      stats,
-                      excluded,
-                      file,
-                      tonumber(added, 10) or 0
-                    )
+              -- parse untracked
+              local untracked_files =
+                vim.split(ls_out.stdout or "", "\n", { trimempty = true })
+              for _, file in ipairs(untracked_files) do
+                local full_path = config_path .. "/" .. file
+                local f = io.open(full_path, "r")
+
+                if f then
+                  local content = f:read "*a" or ""
+                  f:close()
+                  local _, count = content:gsub("\n", "\n")
+                  if content:len() > 0 and content:sub(-1) ~= "\n" then
+                    count = count + 1
                   end
+                  M._process_file(stats, excluded, file, count)
                 end
+              end
 
-                -- parse untracked
-                local untracked_files =
-                  vim.split(ls_out.stdout or "", "\n", { trimempty = true })
-                for _, file in ipairs(untracked_files) do
-                  local full_path = config_path .. "/" .. file
-                  local f = io.open(full_path, "r")
+              if stats.smallest.lines == math.huge then
+                stats.smallest = { name = "None", lines = 0 }
+              end
 
-                  if f then
-                    local content = f:read "*a" or ""
-                    f:close()
-                    local _, count = content:gsub("\n", "\n")
-                    if content:len() > 0 and content:sub(-1) ~= "\n" then
-                      count = count + 1
-                    end
-                    M._process_file(stats, excluded, file, count)
-                  end
-                end
+              local sorted = {}
+              for k, v in pairs(stats.lines_by_type) do
+                table.insert(sorted, { name = k, lines = v })
+              end
+              table.sort(sorted, function(a, b) return a.lines > b.lines end)
+              stats.lines_by_type = sorted
 
-                if stats.smallest.lines == math.huge then
-                  stats.smallest = { name = "None", lines = 0 }
-                end
+              table.sort(
+                stats.top_files,
+                function(a, b) return a.lines > b.lines end
+              )
 
-                local sorted = {}
-                for k, v in pairs(stats.lines_by_type) do
-                  table.insert(sorted, { name = k, lines = v })
-                end
-                table.sort(sorted, function(a, b) return a.lines > b.lines end)
-                stats.lines_by_type = sorted
-
-                table.sort(
-                  stats.top_files,
-                  function(a, b) return a.lines > b.lines end
-                )
-
-                cb(stats)
-              end)
-            end
-          )
+              cb(stats)
+            end)
+          end)
         end
       )
     end

--- a/lua/wrapped/core/files.lua
+++ b/lua/wrapped/core/files.lua
@@ -4,7 +4,14 @@ local M = {}
 ---@return string path
 local function get_path()
   local p = require("wrapped.state").config.path or ""
-  if p:sub(1, 1) == "~" then p = (os.getenv("HOME") or "") .. p:sub(2) end
+  if p:sub(1, 1) == "~" then p = (os.getenv "HOME" or "") .. p:sub(2) end
+  return p
+end
+
+--@return string nvim_root
+local function get_nvim_root()
+  local p = require("wrapped.state").config.nvim_root or ""
+  p = (":/%s"):format(p)
   return p
 end
 
@@ -34,6 +41,7 @@ end
 ---@param cb fun(stats: Wrapped.FileStats)
 function M.get_stats_async(cb)
   local config_path = get_path()
+  local nvim_root = get_nvim_root()
 
   -- get empty tree hash first, then diff against HEAD for per-file line counts
   vim.system(
@@ -60,12 +68,19 @@ function M.get_stats_async(cb)
       -- against empty tree, added = total lines in file
       -- we omit HEAD to include staged and modified tracked files
       vim.system(
-        { "git", "diff", "--numstat", empty_tree },
+        { "git", "diff", "--numstat", empty_tree, "--", nvim_root },
         { cwd = config_path, text = true },
         function(diff_out)
           -- also get untracked files
           vim.system(
-            { "git", "ls-files", "--others", "--exclude-standard" },
+            {
+              "git",
+              "ls-files",
+              "--others",
+              "--exclude-standard",
+              "--",
+              nvim_root,
+            },
             { cwd = config_path, text = true },
             function(ls_out)
               vim.schedule(function()

--- a/lua/wrapped/core/git.lua
+++ b/lua/wrapped/core/git.lua
@@ -4,20 +4,26 @@ local M = {}
 ---@return string path
 local function get_path()
   local p = require("wrapped.state").config.path or ""
-  if p:sub(1, 1) == "~" then p = (os.getenv("HOME") or "") .. p:sub(2) end
+  if p:sub(1, 1) == "~" then p = (os.getenv "HOME" or "") .. p:sub(2) end
+  return p
+end
+
+--@return string nvim_root
+local function get_nvim_root()
+  local p = require("wrapped.state").config.nvim_root or ""
+  p = (":/%s"):format(p)
   return p
 end
 
 ---@param args string[]
 ---@param cb fun(stdout: string)
 local function exec_git(args, cb)
-  vim.system(
-    { "git", unpack(args) },
-    { cwd = get_path(), text = true },
-    function(out)
-      vim.schedule(function() cb(out.stdout or "") end)
-    end
-  )
+  local cmd = { "git" }
+  vim.list_extend(cmd, args)
+  vim.list_extend(cmd, { "--", get_nvim_root() })
+  vim.system(cmd, { cwd = get_path(), text = true }, function(out)
+    vim.schedule(function() cb(out.stdout or "") end)
+  end)
 end
 
 -- seconds to human-readable

--- a/lua/wrapped/core/plugins.lua
+++ b/lua/wrapped/core/plugins.lua
@@ -4,9 +4,17 @@ local M = {}
 ---@return string path
 local function get_path()
   local p = require("wrapped.state").config.path or ""
-  if p:sub(1, 1) == "~" then p = (os.getenv("HOME") or "") .. p:sub(2) end
+  if p:sub(1, 1) == "~" then p = (os.getenv "HOME" or "") .. p:sub(2) end
   return p
 end
+
+--@return string nvim_root
+local function get_nvim_root()
+  local p = require("wrapped.state").config.nvim_root or ""
+  p = (":/%s"):format(p)
+  return p
+end
+
 ---@return integer count
 function M.get_count()
   local ok, lazy = pcall(require, "lazy")
@@ -15,6 +23,7 @@ end
 
 ---@param cb fun(history: Wrapped.PluginHistory)
 function M.get_history_async(cb)
+  local nvim_root = get_nvim_root()
   vim.system({
     "git",
     "log",
@@ -23,7 +32,7 @@ function M.get_history_async(cb)
     "--format=COMMIT_DATE:%ad",
     "--date=iso",
     "--",
-    ":**/*.lua",
+    nvim_root,
   }, { cwd = get_path(), text = true }, function(result)
     if result.code ~= 0 then
       vim.schedule(function() cb { total_ever_installed = 0 } end)

--- a/lua/wrapped/state.lua
+++ b/lua/wrapped/state.lua
@@ -5,6 +5,7 @@ local M = {
   -- user config
   config = {
     path = vim.fn.stdpath "config",
+    nvim_root = "",
     border = false,
     size = { width = 120, height = 40 },
     exclude_filetype = { ".gitmodules" },

--- a/lua/wrapped/types.lua
+++ b/lua/wrapped/types.lua
@@ -4,6 +4,7 @@
 
 ---@class WrappedConfig
 ---@field path string|nil
+---@field nvim_root string|nil
 ---@field border boolean|string|string[]
 ---@field size { width: integer, height: integer }
 ---@field exclude_filetype string[]


### PR DESCRIPTION
Add functionality for setting nvim root

It works by setting the nvim_root config option to the relative path of you nvim root config.
If you have `~/dotfiles/nvim` where `~/dotfiles` contains you `.git` folder you would set `nvim_root = "nvim"`

I have done some basic testing and it seems to be working.